### PR TITLE
Fix extend-with-overflow

### DIFF
--- a/numpy_ringbuffer/__init__.py
+++ b/numpy_ringbuffer/__init__.py
@@ -74,7 +74,7 @@ class RingBuffer(Sequence):
 		if self.is_full:
 			if not self._allow_overwrite:
 				raise IndexError('append to a full RingBuffer with overwrite disabled')
-			elif not len(self):
+			elif not self._capacity:
 				return
 			else:
 				self._left_index += 1
@@ -87,7 +87,7 @@ class RingBuffer(Sequence):
 		if self.is_full:
 			if not self._allow_overwrite:
 				raise IndexError('append to a full RingBuffer with overwrite disabled')
-			elif not len(self):
+			elif not self._capacity:
 				return
 			else:
 				self._right_index -= 1
@@ -117,7 +117,7 @@ class RingBuffer(Sequence):
 		if len(self) + lv > self._capacity:
 			if not self._allow_overwrite:
 				raise IndexError('extend a RingBuffer such that it would overflow, with overwrite disabled')
-			elif not len(self):
+			elif not self._capacity:
 				return
 		if lv >= self._capacity:
 			# wipe the entire array! - this may not be threadsafe
@@ -141,7 +141,7 @@ class RingBuffer(Sequence):
 		if len(self) + lv > self._capacity:
 			if not self._allow_overwrite:
 				raise IndexError('extend a RingBuffer such that it would overflow, with overwrite disabled')
-			elif not len(self):
+			elif not self._capacity:
 				return
 		if lv >= self._capacity:
 			# wipe the entire array! - this may not be threadsafe

--- a/numpy_ringbuffer/__init__.py
+++ b/numpy_ringbuffer/__init__.py
@@ -24,7 +24,8 @@ class RingBuffer(Sequence):
 			full buffer
 		"""
 		# Check parameters
-		assert capacity >= 0, 'capacity must be non-negative'
+		if not capacity >= 0:
+			raise ValueError('capacity must be non-negative')
 
 		self._arr = np.empty(capacity, dtype)
 		self._left_index = 0

--- a/numpy_ringbuffer/__init__.py
+++ b/numpy_ringbuffer/__init__.py
@@ -23,6 +23,11 @@ class RingBuffer(Sequence):
 			If false, throw an IndexError when trying to append to an already
 			full buffer
 		"""
+		# Check parameters
+		if not isinstance(capacity, int):
+			raise TypeError('capacity must be an integer')
+		assert capacity >= 0, 'capacity must be non-negative'
+
 		self._arr = np.empty(capacity, dtype)
 		self._left_index = 0
 		self._right_index = 0

--- a/numpy_ringbuffer/__init__.py
+++ b/numpy_ringbuffer/__init__.py
@@ -24,8 +24,6 @@ class RingBuffer(Sequence):
 			full buffer
 		"""
 		# Check parameters
-		if not isinstance(capacity, int):
-			raise TypeError('capacity must be an integer')
 		assert capacity >= 0, 'capacity must be non-negative'
 
 		self._arr = np.empty(capacity, dtype)

--- a/tests.py
+++ b/tests.py
@@ -95,6 +95,15 @@ class TestAll(unittest.TestCase):
 		r.extend([1, 2, 3, 4, 5, 6, 7])
 		np.testing.assert_equal(r, np.array([3, 4, 5, 6, 7]))
 
+		# test empty extend with overflow
+		r = RingBuffer(5)
+		r.extendleft([1, 2, 3, 4, 5, 6, 7])
+		np.testing.assert_equal(r, np.array([1, 2, 3, 4, 5]))
+
+		r = RingBuffer(5)
+		r.extend([1, 2, 3, 4, 5, 6, 7])
+		np.testing.assert_equal(r, np.array([3, 4, 5, 6, 7]))
+
 	def test_pops(self):
 		r = RingBuffer(3)
 		r.append(1)

--- a/tests.py
+++ b/tests.py
@@ -5,10 +5,10 @@ from numpy_ringbuffer import RingBuffer
 class TestAll(unittest.TestCase):
 	def test_dtype(self):
 		r = RingBuffer(5)
-		self.assertEqual(r.dtype, np.dtype(np.float64))
+		self.assertEqual(r.dtype, np.float64)
 
-		r = RingBuffer(5, dtype=np.bool)
-		self.assertEqual(r.dtype, np.dtype(np.bool))
+		r = RingBuffer(5, dtype=bool)
+		self.assertEqual(r.dtype, bool)
 
 	def test_sizes(self):
 		r = RingBuffer(5, dtype=(int, 2))
@@ -125,7 +125,7 @@ class TestAll(unittest.TestCase):
 			empty.popleft()
 
 	def test_2d(self):
-		r = RingBuffer(5, dtype=(np.float, 2))
+		r = RingBuffer(5, dtype=(float, 2))
 
 		r.append([1, 2])
 		np.testing.assert_equal(r, np.array([[1, 2]]))
@@ -154,7 +154,7 @@ class TestAll(unittest.TestCase):
 			self.assertEqual(i, j)
 
 	def test_repr(self):
-		r = RingBuffer(5, dtype=np.int)
+		r = RingBuffer(5, dtype=int)
 		for i in range(5):
 			r.append(i)
 


### PR DESCRIPTION
Previous behavior:
```python
>>> import numpy as np
>>> from numpy_ringbuffer import RingBuffer
>>> r = RingBuffer(5)
>>> r.extend(np.arange(8))
>>> r
<RingBuffer of array([], dtype=float64)>
```

Expected/fixed behavior:
```python
>>> import numpy as np
>>> from numpy_ringbuffer import RingBuffer
>>> r = RingBuffer(5)
>>> r.extend(np.arange(8))
>>> r
<RingBuffer of array([3., 4., 5., 6., 7.])>
```