### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For example:
 import numpy as np
 from numpy_ringbuffer import RingBuffer
 
-r = RingBuffer(capacity=4, dtype=np.bool)
+r = RingBuffer(capacity=4, dtype=bool)
 r.append(True)
 r.appendleft(False)
 print(np.array(r))  # array([False, True])


### PR DESCRIPTION
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe.